### PR TITLE
Fault injection summary

### DIFF
--- a/bin/injectfault.py
+++ b/bin/injectfault.py
@@ -347,7 +347,7 @@ def main(args):
 
         # print run index before executing. Comma removes newline for prettier
         # formatting
-        print(str(index) + ": "),
+        print(str(index+1) + ": "),
         execlist.extend(optionlist)
         ret = execute(execlist)
         if ret == "timed-out":


### PR DESCRIPTION
During fault injection, each run is now labeled with its index to provide the user a progress report. A brief summary is also printed after all runs are completed, in the form of a histogram of process exit codes. Here is a small example:

```
99:  /home/shaden/src/inject/test/llfi/sum-faultinjection.exe 50
     program finish -11
     time taken 1 

========== SUMMARY ==========
Return codes:
    0:    34
    1:     4
    2:    32
   16:     1
  -11:    27
   -7:     2
```
