### PR TITLE
Converted shebang lines to explicitly use python2

### DIFF
--- a/bin/injectfault.py
+++ b/bin/injectfault.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 """
 

--- a/bin/instrument.py
+++ b/bin/instrument.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 """
 

--- a/bin/profile.py
+++ b/bin/profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 """
 

--- a/setup
+++ b/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 """
 
 Usage: %(prog)s OPTIONS

--- a/tools/compiletoIR.py
+++ b/tools/compiletoIR.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 
 """

--- a/tools/tracediff.py
+++ b/tools/tracediff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 #traceDiff.py
 #  Author: Sam Coulter

--- a/tools/traceontograph.py
+++ b/tools/traceontograph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 #traceOntoGraph.py
 #Author: Sam Coulter

--- a/tools/tracetools.py
+++ b/tools/tracetools.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 #traceTools.py
 #Author: Sam Coulter
 #This file contains library functions and classes for the llfi tracing and

--- a/tools/traceunion.py
+++ b/tools/traceunion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 #traceUnion.py
 #Author: Sam Coulter


### PR DESCRIPTION
Hello all,

The python files used in LLFI are not compatible with python 3, so I converted them to explicitly use the correct python version. Otherwise, conflicts emerge when using systems configured default to python3 (e.g. Arch Linux).
