### PR TITLE
Updating for llvm3.4

### DIFF
--- a/llvm_passes/Controller.cpp
+++ b/llvm_passes/Controller.cpp
@@ -208,7 +208,7 @@ void Controller::processRegSelArgs() {
 void Controller::processCmdArgs() {
   // clear the log file
   std::string err;
-  raw_fd_ostream logFile(llfilogfile.c_str(), err, raw_fd_ostream::F_Append);
+  raw_fd_ostream logFile(llfilogfile.c_str(), err, sys::fs::F_Append);
   if (err == "") {
     logFile << "\n\nStart of a pass\n";
   } else {

--- a/llvm_passes/Controller.h
+++ b/llvm_passes/Controller.h
@@ -1,7 +1,10 @@
 #ifndef CONFIG_H
 #define CONFIG_H
+#define LLVM_ON_UNIX 1
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/FileSystem.h"
 
 #include <set>
 #include <map>

--- a/llvm_passes/FIRegSelector.cpp
+++ b/llvm_passes/FIRegSelector.cpp
@@ -16,7 +16,7 @@ void FIRegSelector::getFIInstRegMap(
     const std::set< Instruction* > *instset, 
     std::map<Instruction*, std::list< Value* >* > *instregmap) {
   std::string err;
-  raw_fd_ostream logFile(llfilogfile.c_str(), err, raw_fd_ostream::F_Append);
+  raw_fd_ostream logFile(llfilogfile.c_str(), err, sys::fs::F_Append);
 
   for (std::set<Instruction*>::const_iterator inst_it = instset->begin();
        inst_it != instset->end(); ++inst_it) {


### PR DESCRIPTION
Updating to LLVM3.4 allows us to better support OSX 10.8 and above with the standard apple dev tools.

The 3.3->3.4 change is rather small.

The only change I am unsure about is forcing the LLVM_ON_UNIX definition in Controller.h, I couldn't get LLFI to compile on OSX without it, but I'm sure there is a better way.

The documentation will also have to change.
