### PR TITLE
Profiling problems in the main function

### DIFF
--- a/llvm_passes/core/Utils.cpp
+++ b/llvm_passes/core/Utils.cpp
@@ -51,6 +51,17 @@ Instruction *getTermInstofFunction(Function *func) {
   BasicBlock &termbb = func->back();
   Instruction *ret = termbb.getTerminator();
 
+  // if the instruction in the last BB is not return/unreachable instruction,
+  // iterate through the main function to find the return/unreachable instruction
+  if( isa<ReturnInst>(ret) || isa<UnreachableInst>(ret) ){}
+  else{
+		for( inst_iterator f_it = inst_begin(func); f_it != inst_end(func); ++f_it ){
+    	if( isa<ReturnInst>(&(*f_it))){
+      	ret = &(*f_it);
+      }
+    }
+  }
+  
   assert(isa<ReturnInst>(ret) || isa<UnreachableInst>(ret) &&
          "Last instruction is not return or exit() instruction");
   return ret;


### PR DESCRIPTION
During profiling, LLFI tries to inject endProfiling callback functions at the end of the main function.
In the original codes, LLFI obtains the last instruction in the last basic block and injects endProfiling before the last instruction. It's generally true in most cases but in some cases the return/unreachable instruction is not always in the last instruction in the last basic block.

In my case, the return instruction is in the BB that is before the last BB in the main function. Therefore, to handle this problem, we'll check if the instruction obtained is return or unreachable instruction. If it's not, then iterate through all the functions in main() to find the real return/unreachable instruction.

**One issue occurred after the modification is not yet solved.** 
When we turn on the "tracingPropagation" option in input.yaml and run the instrumentation, there will be error regarding to the violation of SSA form in LLVM. 





